### PR TITLE
Switch logo to orange

### DIFF
--- a/number_adder/static/assets/favicon.svg
+++ b/number_adder/static/assets/favicon.svg
@@ -2,8 +2,8 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NA">
   <defs>
     <linearGradient id="g" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#2563EB"/>
-      <stop offset="1" stop-color="#60A5FA"/>
+      <stop stop-color="#ff6a00"/>
+      <stop offset="1" stop-color="#ff4500"/>
     </linearGradient>
   </defs>
   <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#g)"/>

--- a/number_adder/static/assets/logo.svg
+++ b/number_adder/static/assets/logo.svg
@@ -2,8 +2,8 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Number Adder logo">
   <defs>
     <linearGradient id="g" x1="32" y1="32" x2="224" y2="224" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#2563EB"/>
-      <stop offset="1" stop-color="#60A5FA"/>
+      <stop stop-color="#ff6a00"/>
+      <stop offset="1" stop-color="#ff4500"/>
     </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
       <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.25"/>


### PR DESCRIPTION
Switches the Number Adder logo + favicon gradient from blue to orange.

Files:
- number_adder/static/assets/logo.svg
- number_adder/static/assets/favicon.svg