### PR TITLE
Fix issue->task workflow branch-exists edge case

### DIFF
--- a/.github/workflows/issue_to_task.yml
+++ b/.github/workflows/issue_to_task.yml
@@ -50,13 +50,22 @@ jobs:
             const { data: baseRef } = await github.rest.git.getRef({ owner, repo, ref: `heads/${baseBranch}` });
             const baseSha = baseRef.object.sha;
 
-            // Create branch
-            await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/heads/${branchName}`,
-              sha: baseSha,
-            });
+            // Create branch (ignore if it already exists)
+            try {
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/heads/${branchName}`,
+                sha: baseSha,
+              });
+            } catch (e) {
+              // 422 => reference already exists
+              if (e.status === 422) {
+                core.info(`Branch ${branchName} already exists; continuing.`);
+              } else {
+                throw e;
+              }
+            }
 
             const body = (issue.body || '').trim();
             const issueUrl = issue.html_url;


### PR DESCRIPTION
Handles the case where the task branch already exists (e.g., after a retry) by continuing instead of failing with Reference already exists.