### PR TITLE
Auto-merge task spec PRs

### DIFF
--- a/.github/workflows/automerge_task_specs.yml
+++ b/.github/workflows/automerge_task_specs.yml
@@ -1,0 +1,62 @@
+name: Auto-merge task spec PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Only run on PRs created from task-spec branches
+    if: startsWith(github.head_ref, 'tasks/issue-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge if this PR only changes tasks/*.md
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            // Fetch changed files
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const allowed = (path) => {
+              if (path === 'tasks/_TEMPLATE.md') return true;
+              if (path.startsWith('tasks/issue-') && path.endsWith('.md')) return true;
+              return false;
+            };
+
+            const disallowed = files.filter(f => !allowed(f.filename));
+            if (disallowed.length > 0) {
+              core.info(`Not auto-merging: found disallowed file changes: ${disallowed.map(d => d.filename).join(', ')}`);
+              return;
+            }
+
+            // Ensure PR is not draft
+            if (context.payload.pull_request.draft) {
+              core.info('PR is draft; skipping auto-merge for now.');
+              return;
+            }
+
+            // Enable auto-merge via GraphQL (merge commit)
+            const prId = context.payload.pull_request.node_id;
+            core.info(`Enabling auto-merge for PR #${pull_number}`);
+
+            await github.graphql(
+              `mutation EnableAutoMerge($prId: ID!) {
+                enablePullRequestAutoMerge(input: { pullRequestId: $prId, mergeMethod: MERGE }) {
+                  pullRequest { number autoMergeRequest { enabledAt } }
+                }
+              }`,
+              { prId }
+            );


### PR DESCRIPTION
Adds a workflow that enables auto-merge for PRs from branches tasks/issue-* when they only change tasks/issue-*.md (and optionally tasks/_TEMPLATE.md).