### PR TITLE
docs: add sanitized 0human v2 templates

### DIFF
--- a/docs/0human/CONFIG.example.env
+++ b/docs/0human/CONFIG.example.env
@@ -1,0 +1,29 @@
+# 0human v2 config (EXAMPLE)
+# Copy this to the VM as /etc/default/ohuman-manager or /etc/default/ohuman-worker
+# and fill in real values.
+
+# --- Common ---
+REPO=adityasudhakar/number-adder
+DEFAULT_BRANCH=master
+
+# GitHub auth token (classic PAT or fine-grained) with permissions to:
+# - read/write issues
+# - read/write pull requests
+# - push branches
+# DO NOT COMMIT REAL TOKENS.
+GH_TOKEN=__FILL_ME__
+
+# Worker identifier (unique per worker VM)
+WORKER_ID=ohuman-worker-1
+
+# --- Agent tool ---
+# If you use Codex CLI, it needs its own auth on the VM.
+# E.g. `codex login --with-api-key` (store the key outside of git).
+CODEX_BIN=/usr/local/bin/codex
+
+# --- Optional: guardrails ---
+# Regex of paths workers are allowed to modify.
+ALLOWED_PATHS='^(number_adder/|tests/|number_adder/static/|claims/)'
+
+# Where to clone the repo / store logs.
+WORK_DIR=/opt/0human

--- a/docs/0human/README.md
+++ b/docs/0human/README.md
@@ -1,0 +1,62 @@
+# 0human v2 (public, sanitized)
+
+This directory documents how we run a **human-free** (a.k.a. “0human”) GitHub Issues → PRs → tests → merge loop using a **manager** VM and multiple **worker** VMs.
+
+It’s intentionally **sanitized**:
+- No cloud credentials
+- No LLM API keys
+- No personal tokens
+- No OAuth client secrets
+
+You should be able to replicate the architecture with your own infra + keys.
+
+## What this system does
+
+1. You create GitHub Issues with a label like `agent:triage`.
+2. A **manager** process:
+   - Enriches the issue into a clear spec
+   - Flips it to `agent:build`
+   - Later reviews worker PRs with deterministic gates (tests, diff allowlist, etc.)
+3. **Workers** pick up `agent:build` issues, implement changes (via your coding agent of choice), run tests, push branches, and open PRs.
+4. The **manager** merges PRs that pass gates and closes the corresponding issue.
+
+## High-level architecture
+
+- **GitHub** is the control plane (labels = state machine)
+- **Manager VM** runs `ohuman-manager.service`
+- **Worker VMs** run `ohuman-worker.service` (one per worker)
+- Secrets live on the VMs in `/etc/default/ohuman-*` (not in git)
+
+## Safety model (recommended defaults)
+
+Deterministic gates should be the source of truth:
+- Only allow changes in a small set of paths (example allowlist)
+- Require tests to pass (`pytest`)
+- Require PR branch to be up-to-date with base
+- Never print secrets in logs
+
+## Files in this folder
+
+- `systemd/` — unit file templates
+- `scripts/` — example manager + worker scripts (sanitized)
+- `CONFIG.example.env` — environment variables you must provide (placeholders)
+
+## Setup checklist (bring your own secrets)
+
+1. Provision 1 manager VM + N worker VMs.
+2. Install:
+   - `git`, `gh` (GitHub CLI)
+   - Python 3.11+
+   - Node (if your agent tooling requires it)
+   - your coding agent CLI (Codex / Claude Code / etc.)
+3. Put secrets on each VM:
+   - `/etc/default/ohuman-manager`
+   - `/etc/default/ohuman-worker`
+4. Install and enable systemd units from `systemd/`.
+5. Create repo labels: `agent:triage`, `agent:build`, `agent:claimed`, `agent:blocked`.
+6. Create an issue with `agent:triage`.
+
+## Notes
+
+- If you’re building a public template, consider moving *all* cloud interaction behind GitHub Actions (wake/sleep) and keeping the VMs “dumb”.
+- If you need stronger guarantees, add branch protection rules + required checks.

--- a/docs/0human/scripts/manager.sh
+++ b/docs/0human/scripts/manager.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sanitized manager script template.
+# Purpose:
+# - Triage issues with label agent:triage → produce a clearer spec → label agent:build
+# - Review worker PRs and merge when deterministic gates pass
+
+REPO=${REPO:?missing REPO}
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-master}
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [manager] $*"; }
+
+# Example: pick the oldest triage issue
+pick_triage_issue() {
+  gh issue list --repo "$REPO" --label agent:triage --state open --limit 1 --json number --jq '.[0].number // empty'
+}
+
+triage_issue() {
+  local issue=$1
+  log "Triaging issue #$issue"
+
+  # In your real system, you’d generate a spec file and post it as a comment.
+  gh issue comment "$issue" --repo "$REPO" --body "(sanitized template) Manager triaged this issue and marked it ready for build."
+  gh issue edit "$issue" --repo "$REPO" --add-label agent:build --remove-label agent:triage
+}
+
+# Deterministic PR gates (examples)
+pr_is_up_to_date() {
+  local pr=$1
+  local base_sha head_sha
+  base_sha=$(gh pr view "$pr" --repo "$REPO" --json baseRefOid --jq .baseRefOid)
+  head_sha=$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)
+  # real check should compare merge base; this is just a placeholder
+  [[ -n "$base_sha" && -n "$head_sha" ]]
+}
+
+run_tests() {
+  # In the real system, create a worktree, install deps, run pytest.
+  log "(template) running tests..."
+}
+
+merge_pr() {
+  local pr=$1
+  log "Merging PR #$pr"
+  gh pr merge "$pr" --repo "$REPO" --merge --delete-branch
+}
+
+main() {
+  log "Starting manager"
+
+  local issue
+  issue=$(pick_triage_issue || true)
+  if [[ -n "${issue:-}" ]]; then
+    triage_issue "$issue"
+  else
+    log "No issues need triage"
+  fi
+
+  # In real system: iterate open worker PRs and apply gates.
+  log "Done"
+}
+
+main "$@"

--- a/docs/0human/scripts/worker-run_once.sh
+++ b/docs/0human/scripts/worker-run_once.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sanitized worker script template.
+# Purpose:
+# - Claim an issue labeled agent:build
+# - Implement changes (via your coding agent)
+# - Run tests
+# - Push a branch and open a PR
+
+REPO=${REPO:?missing REPO}
+WORKER_ID=${WORKER_ID:?missing WORKER_ID}
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-master}
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [worker/$WORKER_ID] $*"; }
+
+pick_build_issue() {
+  gh issue list --repo "$REPO" --label agent:build --state open --limit 20 --json number,labels \
+    --jq '[.[] | select((.labels|map(.name)|index("agent:claimed")|not))][0].number // empty'
+}
+
+claim_issue() {
+  local issue=$1
+  gh issue edit "$issue" --repo "$REPO" --add-label agent:claimed
+}
+
+create_branch() {
+  local issue=$1
+  echo "worker/${WORKER_ID}/issue-${issue}"
+}
+
+main() {
+  log "Starting worker"
+
+  local issue
+  issue=$(pick_build_issue || true)
+  if [[ -z "${issue:-}" ]]; then
+    log "No available issues found"
+    exit 0
+  fi
+
+  log "Claiming issue #$issue"
+  claim_issue "$issue"
+
+  local branch
+  branch=$(create_branch "$issue")
+  log "Using branch $branch"
+
+  # Real system steps (template):
+  # 1) git clone/fetch
+  # 2) checkout -b "$branch" origin/$DEFAULT_BRANCH
+  # 3) run coding agent to implement
+  # 4) pytest
+  # 5) git push origin "$branch"
+  # 6) gh pr create
+
+  log "(template) Implement + test + PR create here"
+}
+
+main "$@"

--- a/docs/0human/systemd/ohuman-manager.service
+++ b/docs/0human/systemd/ohuman-manager.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=0human Manager (sanitized template)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/0human/manager
+EnvironmentFile=/etc/default/ohuman-manager
+ExecStart=/opt/0human/manager/manager.sh
+User=hellouser
+Group=hellouser
+
+# Hardening (adjust to your needs)
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/0human/systemd/ohuman-manager.timer
+++ b/docs/0human/systemd/ohuman-manager.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run 0human Manager periodically
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=ohuman-manager.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/0human/systemd/ohuman-worker.service
+++ b/docs/0human/systemd/ohuman-worker.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=0human Worker (sanitized template)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/0human/worker
+EnvironmentFile=/etc/default/ohuman-worker
+ExecStart=/opt/0human/worker/run_once.sh
+User=hellouser
+Group=hellouser
+
+# If you want looping behavior, wrap run_once.sh with a small loop script.
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/0human/systemd/ohuman-worker.timer
+++ b/docs/0human/systemd/ohuman-worker.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run 0human Worker periodically
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=ohuman-worker.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds a sanitized, public-safe set of docs + templates for running a 0human (manager+worker) pipeline.

Includes:
- High-level README
- Example env config (placeholders only)
- systemd unit + timer templates
- Template manager/worker scripts (no secrets)

No keys/tokens are included.